### PR TITLE
GA4GHTT-231 war plugin + readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Run with config file
 ./gradlew bootRun --args="--config path/to/config.yml"
 ```
 
-Alternatively, the service can be built as a jar and run:
+Alternatively, the service can be built as a jar and/or war and run:
 
 Build jar:
 ```
@@ -115,6 +115,21 @@ java -jar build/libs/ga4gh-starter-kit-drs-${VERSION}.jar
 Run with config file
 ```
 java -jar build/libs/ga4gh-starter-kit-drs-${VERSION}.jar --config path/to/config.yml
+```
+
+Build war:
+```
+./gradlew bootWar
+```
+
+Run with all defaults
+```
+java -jar build/libs/ga4gh-starter-kit-drs-${VERSION}.war
+```
+
+Run with config file
+```
+java -jar build/libs/ga4gh-starter-kit-drs-${VERSION}.war --config path/to/config.yml
 ```
 
 ### Confirm server is running

--- a/README.md
+++ b/README.md
@@ -265,3 +265,7 @@ Multiple datasets are currently contained in this repo for development and testi
 ### v0.2.2
 
 * patched log4j dependencies to v2.16.0 to avoid [Log4j Vulnerability](https://www.cisa.gov/uscert/apache-log4j-vulnerability-guidance)
+
+## Maintainers
+
+* GA4GH Tech Team [ga4gh-tech-team@ga4gh.org](mailto:ga4gh-tech-team@ga4gh.org)

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,8 @@ plugins {
     id 'jacoco'
 
     id 'io.codearte.nexus-staging' version '0.30.0'
+
+    id 'war'
 }
 
 configurations.all {


### PR DESCRIPTION
updated README for commands, pretty much copy paste from jar file 

able to generate war file with bootWar, and execute + communicate with service-info endpoint at port 4500

@dashrath-chauhan can confirm that it's running on Tomcat webserver

also added maintainers contact info to README